### PR TITLE
Fix dismissable and cookie settings for notice

### DIFF
--- a/inc/custom-meta-box.php
+++ b/inc/custom-meta-box.php
@@ -3,7 +3,7 @@
  * @Author: Niku Hietanen
  * @Date: 2020-06-26 14:00:00
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2020-10-06 14:02:38
+ * @Last Modified time: 2021-02-11 16:34:09
  * @package air-notifications
  */
 
@@ -106,7 +106,11 @@ function register_meta_boxes() {
         'desc'    => esc_html__( 'User can dismiss the notification', 'air-notifications' ),
         'id'      => 'air_notification_dismissable',
         'default' => isset( $_GET['post'] ) ? '' : $settings['defaults']['dismissable'], // Set default only on new posts
-        'type'    => 'checkbox',
+        'type'    => 'radio_inline',
+        'options' => [
+          'on'  => esc_html__( 'Yes', 'air-notifications' ),
+          'off' => esc_html__( 'No', 'air-notifications' ),
+        ],
       ]
     );
 
@@ -120,7 +124,11 @@ function register_meta_boxes() {
         'desc'    => esc_html__( 'User will not see the notification again after dismissing it', 'air-notifications' ),
         'id'      => 'air_notification_cookie',
         'default' => isset( $_GET['post'] ) ? '' : $settings['defaults']['cookie'], // Set default only on new posts
-        'type'    => 'checkbox',
+        'type'    => 'radio_inline',
+        'options' => [
+          'on'  => esc_html__( 'Yes', 'air-notifications' ),
+          'off' => esc_html__( 'No', 'air-notifications' ),
+        ],
       ]
     );
 

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -4,8 +4,8 @@
  *
  * @Author: Niku Hietanen
  * @Date: 2020-06-25 15:19:26
- * @Last Modified by:   Roni Laukkarinen
- * @Last Modified time: 2020-10-07 11:28:38
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2021-02-11 16:35:26
  * @package air-notifications
  */
 
@@ -122,7 +122,7 @@ function single_notification( $notification ) {
 
   $classes = 'air-notification';
   $classes .= ' air-notification--' . $notification['type'];
-  $classes .= $notification['dismissable'] ? ' air-notification--dismissable' : '';
+  $classes .= ( 'on' === $notification['dismissable'] ) ? ' air-notification--dismissable' : '';
 
   $output = '<div class="' . $classes . '" id="' . $id . '" data-save-cookie="' . $notification['cookie'] . '">';
 
@@ -132,12 +132,11 @@ function single_notification( $notification ) {
 
   $output .= '<span class="air-notification__content">' . wp_kses_post( $notification['content'] ) . '</span>';
 
-
   if ( $type_settings['append'] ) {
     $output .= '<span class="air-notification__append">' . $type_settings['append'] . '</span>';
   }
 
-  if ( $notification['dismissable'] ) {
+  if ( 'on' === $notification['dismissable'] ) {
     $output .= '<button type="button" class="air-notification__close" data-notification-id="' . $id . '"><span aria-hidden="true">' . $notification_settings['dismissable_icon'] . '</span><span class="screen-reader-text">' . __( 'Close notification', 'air-notifications' ) . '</span></button>';
   }
 
@@ -212,8 +211,8 @@ function get_notification_settings() {
       'schedule_end' => true,
     ],
     'defaults' => [
-      'cookie'      => false,
-      'dismissable' => true,
+      'cookie'      => 'off',
+      'dismissable' => 'on',
       'location'    => 'default',
       'type'        => 'notice',
     ],


### PR DESCRIPTION
The plugin uses CMB2 checkboxes for dismissable and cookie settings per notice. The way how CMB2 treats unchecked checkbox is by removing the meta field completely. Because the meta isn't there, notice setting does fallback to defaults settings which are general for all notices. This makes the per notice options virtually non-usable.

PR changes the `checkbox` inputs to `radio_inline` and adds two options: Yes (on) or No (off). This way some value will always be saved in the database.

By using on and off as the values, we avoid a situation where string true/false is interpreted as boolean false causing general defaults kicking in. Also, CMB2 uses "on" as a value for checked checkbox so using the same naming convention is backwards compatible.