### PR TITLE
Semantic structure update, Fixes #3

### DIFF
--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -128,7 +128,7 @@ function single_notification( $notification ) {
   $classes .= ' air-notification--' . $notification['type'];
   $classes .= ( 'on' === $notification['dismissable'] ) ? ' air-notification--dismissable' : '';
 
-  $output = '<div class="' . $classes . '" id="' . $id . '" data-save-cookie="' . $notification['cookie'] . '" aria-hidden="true">';
+  $output = '<div class="' . $classes . '" id="' . $id . '" data-save-cookie="' . $notification['cookie'] . '" aria-hidden="true"><p>';
 
   if ( $type_settings['prepend'] ) {
     $output .= '<span class="air-notification__prepend">' . $type_settings['prepend'] . '</span>';
@@ -144,7 +144,7 @@ function single_notification( $notification ) {
     $output .= '<button type="button" class="air-notification__close" data-notification-id="' . $id . '"><span aria-hidden="true">' . $notification_settings['dismissable_icon'] . '</span><span class="screen-reader-text">' . __( 'Close notification', 'air-notifications' ) . '</span></button>';
   }
 
-  $output .= '</div>';
+  $output .= '</p></div>';
 
   return \apply_filters( 'air_notifications_single_notification', $output, $notification );
 }

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -140,11 +140,13 @@ function single_notification( $notification ) {
     $output .= '<span class="air-notification__append">' . $type_settings['append'] . '</span>';
   }
 
+  $output .= '</p>';
+
   if ( 'on' === $notification['dismissable'] ) {
     $output .= '<button type="button" class="air-notification__close" data-notification-id="' . $id . '"><span aria-hidden="true">' . $notification_settings['dismissable_icon'] . '</span><span class="screen-reader-text">' . __( 'Close notification', 'air-notifications' ) . '</span></button>';
   }
 
-  $output .= '</p></div>';
+  $output .= '</div>';
 
   return \apply_filters( 'air_notifications_single_notification', $output, $notification );
 }


### PR DESCRIPTION
This PR wraps notifcation content to paragraph to improve semantics. Button is left outside so for it's easier to align items with flex and `justify-content: space-between;` without having to use position absolute with close button.

In summary: This HTML structure allows more flexible styling.